### PR TITLE
to stay consistent with the rest of the api, wrapping the response in…

### DIFF
--- a/docs/source/development/traffic_ops_api/v12/parameter.rst
+++ b/docs/source/development/traffic_ops_api/v12/parameter.rst
@@ -100,14 +100,19 @@ Parameter
 
   **Response Example** ::
 
+  **Response Example** ::
+
     {
-     "response": {
-           "id": 1,
+     "response": [
+        {
+           "last_updated": "2012-09-17 21:41:22",
            "secure": 0,
            "value": "foo.bar.net",
            "name": "domain_name",
+           "id": "27",
            "config_file": "FooConfig.xml"
         }
+     ]
     }
 
 |

--- a/traffic_ops/app/lib/API/Parameter.pm
+++ b/traffic_ops/app/lib/API/Parameter.pm
@@ -173,14 +173,18 @@ sub get {
         return $self->forbidden("You must be an admin to perform this operation!");
     }
 
-    my $response;
-    $response->{id}     = $find->id;
-    $response->{name}   = $find->name;
-    $response->{configFile} = $find->config_file;
-    $response->{value}  = $find->value;
-    $response->{secure} = $find->secure;
-
-    return $self->success($response, "Get parameter successfully.");
+	my @data = ();
+	push(
+		@data, {
+			"id"          => $find->id,
+			"name"        => $find->name,
+			"configFile"  => $find->config_file,
+			"value"       => $find->value,
+			"secure"      => \$find->secure,
+			"lastUpdated" => $find->last_updated
+		}
+	);
+	$self->success( \@data );
 }
 
 sub edit {


### PR DESCRIPTION
… an array. 

also, i in `api/parameters/:id` i casted the 0|1 into a boolean to stay consistent with the rest of the api. 

can you make sure the other routes (POST and PUT) accept true|false for secure and then turn it into 0|1 when adding it to the database?
